### PR TITLE
Beyond the next red light, target velocity should be zero not MAX_VELOCITY.

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -54,13 +54,14 @@ class WaypointUpdater(object):
             self.calculate_and_publish_next_waypoints()
             r.sleep()
 
-    def calculate_waypoint_velocity(self, waypoint_index):
+    def get_default_velocity(self):
         if self.ever_received_traffic_waypoint and self.waypoints:
-            velocity = self.MAX_VELOCITY
+            return self.MAX_VELOCITY
         else:
             rospy.loginfo('Waiting for waypoints or red-light info, so set zero target velocity.')
-            velocity = 0
+            return 0
 
+    def calculate_waypoint_velocity(self, waypoint_index):
         if self.next_red_light and self.waypoints:
             if waypoint_index <= self.next_red_light:
                 distance_to_red_light = self.distance(self.waypoints, waypoint_index, self.next_red_light)
@@ -69,8 +70,12 @@ class WaypointUpdater(object):
                 elif (distance_to_red_light < self.REDUCE_SPEED_DISTANCE):
                     ratio = distance_to_red_light / self.REDUCE_SPEED_DISTANCE
                     velocity = self.MAX_VELOCITY * ratio
+                else:
+                    velocity = self.get_default_velocity()
             else:
                 velocity = 0.0
+        else:
+            velocity = self.get_default_velocity()
 
         if velocity > self.MAX_VELOCITY:
             velocity = self.MAX_VELOCITY

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -61,13 +61,16 @@ class WaypointUpdater(object):
             rospy.loginfo('Waiting for waypoints or red-light info, so set zero target velocity.')
             velocity = 0
 
-        if self.next_red_light and self.waypoints and (waypoint_index <= self.next_red_light):
-            distance_to_red_light = self.distance(self.waypoints, waypoint_index, self.next_red_light)
-            if (distance_to_red_light < self.STOP_DISTANCE):
+        if self.next_red_light and self.waypoints:
+            if waypoint_index <= self.next_red_light:
+                distance_to_red_light = self.distance(self.waypoints, waypoint_index, self.next_red_light)
+                if (distance_to_red_light < self.STOP_DISTANCE):
+                    velocity = 0.0
+                elif (distance_to_red_light < self.REDUCE_SPEED_DISTANCE):
+                    ratio = distance_to_red_light / self.REDUCE_SPEED_DISTANCE
+                    velocity = self.MAX_VELOCITY * ratio
+            else:
                 velocity = 0.0
-            elif (distance_to_red_light < self.REDUCE_SPEED_DISTANCE):
-                ratio = distance_to_red_light / self.REDUCE_SPEED_DISTANCE
-                velocity = self.MAX_VELOCITY * ratio
 
         if velocity > self.MAX_VELOCITY:
             velocity = self.MAX_VELOCITY


### PR DESCRIPTION
I previously reported a bug where waypoint_updater returns MAX_VELOCITY for waypoints beyond the next red light. If the car passes the stop line due to imprecise control, then it will run the red light. Here's a video of this bug: https://youtu.be/FwGnLUl1jEU

Here is a video of this change: https://youtu.be/Koed1puu6-A