### PR TITLE
Reduce max throttle to be in line with successful Carla run.

### DIFF
--- a/ros/src/twist_controller/launch/dbw.launch
+++ b/ros/src/twist_controller/launch/dbw.launch
@@ -5,8 +5,8 @@
         <param name="fuel_capacity" value="13.5" />
         <param name="brake_deadband" value=".1" />
         <param name="brake_factor" value="1.0" />
-        <param name="decel_limit" value="-0.8" />
-        <param name="accel_limit" value="0.8" />
+        <param name="decel_limit" value="-0.25" />
+        <param name="accel_limit" value="0.025" />
         <param name="wheel_radius" value="0.2413" />
         <param name="wheel_base" value="2.8498" />
         <param name="steer_ratio" value="14.8" />


### PR DESCRIPTION
Reduce max throttle to be in line with successful Carla run, which outputs a throttle of 0.025. Fix bug on Carla where 'DBW would disengage after a few seconds each time we engaged. This could be due to fairly rapid acceleration from standstill, which should be more gradual.'